### PR TITLE
Set up API documentation

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,37 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "0.1.0",
+    "title": "fIT Minds API",
+    "description": "Backend for the fIT Minds project. A workplace training platform which uses Strava for data collection."
+  },
+  "servers": [
+    {
+      "url": "https://fitminds.run/api/v1"
+    }
+  ],
+  "paths": {
+    "/ping": {
+      "get": {
+        "description": "Verify the API is up, and for how long.",
+        "responses": {
+          "200": {
+            "description": "Successfully returned the uptime of the system reported in seconds.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "uptime": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -341,6 +341,19 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
+    "swagger-ui-dist": {
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.25.0.tgz",
+      "integrity": "sha512-vwvJPPbdooTvDwLGzjIXinOXizDJJ6U1hxnJL3y6U3aL1d2MSXDmKg2139XaLBhsVZdnQJV2bOkX4reB+RXamg=="
+    },
+    "swagger-ui-express": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-f8SEn4YWkKh/HGK0ZjuA2VqA78i1aY6OIa5cqYNgOkBobfHV6Mz4dphQW/us8HYhEFfbENq329PyfIonWfzFrw==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
+      }
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/alehel/fitminds-backend#readme",
   "dependencies": {
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "swagger-ui-express": "^4.1.3"
   }
 }

--- a/server.js
+++ b/server.js
@@ -4,6 +4,13 @@ const app = express();
 
 const port = process.env.PORT || 1337;
 
-app.get('/v1/ping', api.pong);
+// set up swagger-ui
+const swaggerUi = require('swagger-ui-express');
+const swaggerDocument = require('./openapi.json');
+app.use('/api/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
+// routes
+app.get('/api/v1/ping', api.pong);
+
+// start server
 app.listen(port, () => console.log(`Server listening on port ${port}`));


### PR DESCRIPTION
Set up of API documentation. Documentation is written using OpenAPI 3.0 specification. The resulting documenation is available to the end user at /api/api-docs using Swagger UI.

**New project dependency**
[swagger-ui-express](https://www.npmjs.com/package/swagger-ui-express): Takes the OpenAPI document (openapi.json) and makes it available at /api/api-docs using Swagger UI. 